### PR TITLE
fix compile error for crystl ver 0.16 later

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pg_connect "postgres://user@host:5432/your_db"
 
 # Make sure to yield `env`.
 get "/" do |env|
-  users = conn.exec("SELECT * FROM users")
+  users = connection.exec("SELECT * FROM users")
   # Release the connection after you are done with exec
   release
   "Hello from postgresql"

--- a/src/kemal-pg.cr
+++ b/src/kemal-pg.cr
@@ -2,7 +2,7 @@ require "pg"
 require "pool/connection"
 require "http"
 
-macro conn
+macro connection
   env.pg.connection
 end
 
@@ -15,12 +15,12 @@ def pg_connect(conn_url, capacity = 25, timeout = 0.1)
 end
 
 class HTTP::Server::Context
-  property! pg
+  property! pg : ConnectionPool(PG::Connection)
 end
 
 class Kemal::PG < HTTP::Handler
   def initialize(conn_url, capacity, timeout)
-    @pg = ConnectionPool.new(capacity: capacity, timeout: timeout) do
+    @pg = ConnectionPool(PG::Connection).new(capacity: capacity, timeout: timeout) do
       ::PG.connect(conn_url)
     end
   end


### PR DESCRIPTION
For [Issues1](https://github.com/sdogruyol/kemal-pg/issues/1)
- When crystal ver 0.16 later,  instance and class variable type must have determined in the class.
- Avoid a collision of variable name to expand in the macro
